### PR TITLE
remove the hack on multiIndex

### DIFF
--- a/odc/algo/io.py
+++ b/odc/algo/io.py
@@ -134,13 +134,6 @@ def _load_with_native_transform_1(
     if groupby is not None:
         if fuser is None:
             fuser = _nodata_fuser  # type: ignore
-
-        for dim in xx.dims:
-            if isinstance(xx.get_index(dim), pd.MultiIndex):
-                xx = xx.reset_index(dim)
-
-        if groupby not in xx.indexes.keys():
-            xx = xx.set_xindex(groupby)
         xx = xx.groupby(groupby).map(fuser)
 
     _chunks = None
@@ -247,11 +240,6 @@ def load_with_native_transform(
     else:
         xx = xr.concat(_xx, sources.dims[0])  # type: ignore
         if groupby != "idx":
-            for dim in xx.dims:
-                if isinstance(xx.get_index(dim), pd.MultiIndex):
-                    xx = xx.reset_index(dim)
-            if groupby not in xx.indexes.keys():
-                xx = xx.set_xindex(groupby)
             xx = xx.groupby(groupby).map(fuser)
 
     # TODO: probably want to replace spec MultiIndex with just `time` component


### PR DESCRIPTION
The `pd.MultiIndex` hack was added to enable `xarray>=2023.3.0`. Remove it in this pr, as
- it was not required for `xarray>2023.6.0`
- it is incompatible with `pandas>=2.0` and hence cause `NaT` in `solar_day` dimension after `groupby=solar_day`.