### PR TITLE
Fix geomedian chunk misplacement

### DIFF
--- a/odc/algo/_masking.py
+++ b/odc/algo/_masking.py
@@ -12,6 +12,7 @@ import xarray as xr
 from dask.highlevelgraph import HighLevelGraph
 from functools import partial
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
+import uuid
 
 from ._dask import _get_chunks_asarray, randomize
 
@@ -150,12 +151,12 @@ def erase_bad(x, where, inplace=False, nodata=None):
 def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None, out=None):
     scale = np.float32(scale)
     offset = np.float32(offset)
-
-    if out is None:
-        out = np.empty_like(x, dtype=dtype)
-    else:
-        assert out.shape == x.shape
-
+    
+    # if out is None:
+    #     out = np.empty_like(x, dtype=dtype)
+    # else:
+    #     assert out.shape == x.shape
+        
     params = dict(x=x, nodata=nodata, scale=scale, offset=offset)
 
     # `x == x` is equivalent to `~np.isnan(x)`
@@ -166,10 +167,9 @@ def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None, out=None):
         expr = "where((x == x)&m, x*scale + offset, nodata)"
     else:
         expr = "where(x == x, x*scale + offset, nodata)"
-
-    ne.evaluate(expr, local_dict=params, out=out, casting="unsafe")
-
-    return out
+        
+    return ne.evaluate(expr, local_dict=params, out=out, casting="unsafe")
+    # return out
 
 
 def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
@@ -180,10 +180,11 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
     offset = float_type(offset)
 
     params = dict(_nan=_nan, scale=scale, offset=offset, x=x, nodata=nodata)
-    if out is None:
-        out = np.empty_like(x, dtype=dtype)
-    else:
-        assert out.shape == x.shape
+    # if out is None:
+    #     out = np.empty_like(x, dtype=dtype)
+    # else:
+    #     assert out.shape == x.shape
+    # print("let numpexpr allocate memories")
 
     if nodata is None:
         return ne.evaluate(
@@ -200,6 +201,7 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
             casting="unsafe",
             local_dict=params,
         )
+    # return out
 
 
 def to_f32_np(x, nodata=None, scale=1, offset=0, out=None):

--- a/odc/algo/_masking.py
+++ b/odc/algo/_masking.py
@@ -152,6 +152,8 @@ def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None, out=None):
     scale = float_type(scale)
     offset = float_type(offset)
 
+    # warnings: Do NOT allocate memory for ne.evaluate in multithreading
+    # as it will introduce race-condition
     if out is not None:
         assert out.shape == x.shape
 
@@ -177,6 +179,9 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
     offset = float_type(offset)
 
     params = dict(_nan=_nan, scale=scale, offset=offset, x=x, nodata=nodata)
+
+    # warnings: Do NOT allocate memory for ne.evaluate in multithreading
+    # as it will introduce race-condition
     if out is not None:
         assert out.shape == x.shape
 

--- a/odc/algo/_masking.py
+++ b/odc/algo/_masking.py
@@ -12,7 +12,6 @@ import xarray as xr
 from dask.highlevelgraph import HighLevelGraph
 from functools import partial
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
-import uuid
 
 from ._dask import _get_chunks_asarray, randomize
 
@@ -149,14 +148,13 @@ def erase_bad(x, where, inplace=False, nodata=None):
 
 
 def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None, out=None):
-    scale = np.float32(scale)
-    offset = np.float32(offset)
-    
-    # if out is None:
-    #     out = np.empty_like(x, dtype=dtype)
-    # else:
-    #     assert out.shape == x.shape
-        
+    float_type = np.dtype(dtype).type
+    scale = float_type(scale)
+    offset = float_type(offset)
+
+    if out is not None:
+        assert out.shape == x.shape
+
     params = dict(x=x, nodata=nodata, scale=scale, offset=offset)
 
     # `x == x` is equivalent to `~np.isnan(x)`
@@ -167,9 +165,8 @@ def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None, out=None):
         expr = "where((x == x)&m, x*scale + offset, nodata)"
     else:
         expr = "where(x == x, x*scale + offset, nodata)"
-        
+
     return ne.evaluate(expr, local_dict=params, out=out, casting="unsafe")
-    # return out
 
 
 def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
@@ -180,19 +177,12 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
     offset = float_type(offset)
 
     params = dict(_nan=_nan, scale=scale, offset=offset, x=x, nodata=nodata)
-    # if out is None:
-    #     out = np.empty_like(x, dtype=dtype)
-    # else:
-    #     assert out.shape == x.shape
-    # print("let numpexpr allocate memories")
+    if out is not None:
+        assert out.shape == x.shape
 
     if nodata is None:
         return ne.evaluate(
             "x*scale + offset", out=out, casting="unsafe", local_dict=params
-        )
-    elif scale == 1 and offset == 0:
-        return ne.evaluate(
-            "where(x == nodata, _nan, x)", out=out, casting="unsafe", local_dict=params
         )
     else:
         return ne.evaluate(
@@ -201,7 +191,6 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype="float32", out=None):
             casting="unsafe",
             local_dict=params,
         )
-    # return out
 
 
 def to_f32_np(x, nodata=None, scale=1, offset=0, out=None):

--- a/odc/algo/_memsink.py
+++ b/odc/algo/_memsink.py
@@ -273,8 +273,16 @@ def _da_from_mem(
     for idx in np.ndindex(shape_in_chunks):
         dsk[(name, *idx)] = (_chunk_extractor, token.key, _roi(idx))
         dsk[name].append((name, *idx))
-
+    import json 
+    with open("/home/jovyan/dask_keys.txt", "w") as f:
+        f.write(json.dumps(list(dsk.keys())))
+        f.write("\n")
+        f.write(json.dumps(list(set(dsk.keys()))))
+    print(f"dask chunk keys {len(list(dsk.keys()))}")
+    print(f"dask chunk keys {len(set(dsk.keys()))}")
     dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[token])
+    with open("/home/jovyan/chunk_map.html", "w") as f:
+        f.write(dsk._repr_html_())
 
     return da.Array(dsk, name, shape=shape, dtype=dtype, chunks=_chunks)
 
@@ -369,6 +377,8 @@ def da_yxbt_sink(
     dsk = dict(fut.dask)
     dsk[sink_name] = (lambda *x: x[0], token.key, *fut.dask[fut.key])
     dsk = HighLevelGraph.from_collections(sink_name, dsk, dependencies=sinks)
+    with open("/home/jovyan/yxbt_sink_map.html", "w") as f:
+        f.write(dsk._repr_html_())
     token_done = Delayed(sink_name, dsk)
 
     return _da_from_mem(token_done, shape=shape, dtype=dtype, chunks=chunks, name=name)

--- a/odc/algo/_memsink.py
+++ b/odc/algo/_memsink.py
@@ -273,16 +273,8 @@ def _da_from_mem(
     for idx in np.ndindex(shape_in_chunks):
         dsk[(name, *idx)] = (_chunk_extractor, token.key, _roi(idx))
         dsk[name].append((name, *idx))
-    import json 
-    with open("/home/jovyan/dask_keys.txt", "w") as f:
-        f.write(json.dumps(list(dsk.keys())))
-        f.write("\n")
-        f.write(json.dumps(list(set(dsk.keys()))))
-    print(f"dask chunk keys {len(list(dsk.keys()))}")
-    print(f"dask chunk keys {len(set(dsk.keys()))}")
+
     dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[token])
-    with open("/home/jovyan/chunk_map.html", "w") as f:
-        f.write(dsk._repr_html_())
 
     return da.Array(dsk, name, shape=shape, dtype=dtype, chunks=_chunks)
 
@@ -377,8 +369,6 @@ def da_yxbt_sink(
     dsk = dict(fut.dask)
     dsk[sink_name] = (lambda *x: x[0], token.key, *fut.dask[fut.key])
     dsk = HighLevelGraph.from_collections(sink_name, dsk, dependencies=sinks)
-    with open("/home/jovyan/yxbt_sink_map.html", "w") as f:
-        f.write(dsk._repr_html_())
     token_done = Delayed(sink_name, dsk)
 
     return _da_from_mem(token_done, shape=shape, dtype=dtype, chunks=chunks, name=name)


### PR DESCRIPTION
To resolve the issue in `odc-stats` regards to geomedian ref: https://github.com/opendatacube/odc-stats/issues/100. The issue was caused by the race-condition on `numexpr.evaluate` when allocating the memory out of the function in multi-threading.
changes:
- let `numexpr.evaluate` allocate memory and return the pointer
- hold the input memory pointer until the end of geomedian function  to be safer
- pack scale and geomad calculation into geomedian function for the sake of cpu and memory efficiency
- some cleanup in scale functions

I don't have a better way to test geomedian here than in `odc-stats` atm.