### PR TITLE
Use correct package name for returning version

### DIFF
--- a/odc/algo/__init__.py
+++ b/odc/algo/__init__.py
@@ -56,7 +56,7 @@ from ._tiff import save_cog
 from importlib.metadata import version
 from ._warp import xr_reproject
 
-__version__ = version("odc-stats")
+__version__ = version("odc-algo")
 
 __all__ = (
     "apply_numexpr",


### PR DESCRIPTION
This package is `odc-algo`, not `odc-stats`. This was making it impossible to run the tests or any of the code without `odc-stats` being installed.

