### PR TITLE
Pin dask version to prevent breakage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     dask
     dask_image
     datacube>=1.8.5
-    distributed
+    distributed<2025.4  # 2025.4.0 breaks memsink
     numexpr
     numpy
     rasterio>=1.3.2


### PR DESCRIPTION
Something breaks in MemSink with Dask >= 2025.4. Need to fix later.