### PR TITLE
update memsink and release dask pin

### DIFF
--- a/odc/algo/_memsink.py
+++ b/odc/algo/_memsink.py
@@ -12,13 +12,13 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 from dask.base import tokenize
-from dask.delayed import Delayed
 
 from ._dask import _roi_from_chunks, unpack_chunks
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
 
+    from dask.delayed import Delayed
     from distributed import Client
 
 ShapeLike = int | tuple[int, ...]
@@ -306,7 +306,6 @@ def _da_from_mem(
         arr[tuple(arr_idx)] = d
 
     darr = da.block(arr.tolist())
-    print(darr)
 
     return darr
 

--- a/odc/algo/_memsink.py
+++ b/odc/algo/_memsink.py
@@ -44,7 +44,6 @@ class Token:
         return len(self._k) > 0
 
     def release(self):
-        # print(f"token is released {self}")
         if self:
             Cache.pop(self)
             self._k = ""
@@ -94,7 +93,7 @@ class Cache:
             return Cache.get(k)
 
     @staticmethod
-    def put(x: np.ndarray):
+    def put(x: np.ndarray) -> Token:
         k = uuid.uuid4().hex
         _cache[k] = x
         return Token(k)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "affine",
     "dask",
     "dask-image",
-    "distributed<2025.4",  # Breaks memsink
+    "distributed",
     "numexpr",
     "numpy",
     "rasterio>=1.3.2",


### PR DESCRIPTION
As the title. There were breaking changes of `dask.store`, ref: https://github.com/dask/dask/issues/11921
It returns a list of `dask.array` instead of `graph`, hence changed the code to manipulate `dask.array` and `dask.delayed`, instead of `unpacking` and `packing` graph (though under the hood it is.).