### PR TITLE
fix: dask map_blocks needs unique name

### DIFF
--- a/odc/algo/_geomedian.py
+++ b/odc/algo/_geomedian.py
@@ -432,7 +432,12 @@ def geomedian_with_mads(
         num_threads=num_threads,
     )
     _gm = da.map_blocks(
-        op, yxbt.data, dtype="float32", drop_axis=3, chunks=chunks, name=randomize("geomedian"),
+        op,
+        yxbt.data,
+        dtype="float32",
+        drop_axis=3,
+        chunks=chunks,
+        name=randomize("geomedian"),
     )
 
     if out_chunks is not None:

--- a/odc/algo/_geomedian.py
+++ b/odc/algo/_geomedian.py
@@ -432,7 +432,7 @@ def geomedian_with_mads(
         num_threads=num_threads,
     )
     _gm = da.map_blocks(
-        op, yxbt.data, dtype="float32", drop_axis=3, chunks=chunks, name="geomedian"
+        op, yxbt.data, dtype="float32", drop_axis=3, chunks=chunks, name=randomize("geomedian"),
     )
 
     if out_chunks is not None:

--- a/odc/algo/_masking.py
+++ b/odc/algo/_masking.py
@@ -734,6 +734,7 @@ def _da_fuse_with_custom_op(xx: da.Array, op, name="fuse") -> da.Array:
     Out[0, y, x] = op(In[0:1, y, x], In[1:2, y, x], In[2:3, y, x]...)
 
     """
+    name = randomize(name)
     can_do_flat = all(ch == 1 for ch in xx.chunks[0])
     if not can_do_flat:
         slices = [xx[i : i + 1] for i in range(xx.shape[0])]
@@ -741,7 +742,6 @@ def _da_fuse_with_custom_op(xx: da.Array, op, name="fuse") -> da.Array:
 
     chunks, _ = _get_chunks_asarray(xx)
     dsk = {}
-    name = randomize(name)
     for idx in np.ndindex(chunks.shape[1:]):
         blocks = chunks[(slice(None), *idx)].ravel()
         dsk[(name, 0, *idx)] = (op, *blocks)

--- a/odc/algo/_memsink.py
+++ b/odc/algo/_memsink.py
@@ -14,7 +14,7 @@ import xarray as xr
 from dask.base import tokenize
 from dask.graph_manipulation import bind
 
-from ._dask import _roi_from_chunks, unpack_chunks, randomize
+from ._dask import _roi_from_chunks, randomize, unpack_chunks
 
 if TYPE_CHECKING:
     from collections.abc import Hashable

--- a/odc/algo/_memsink.py
+++ b/odc/algo/_memsink.py
@@ -14,7 +14,7 @@ import xarray as xr
 from dask.base import tokenize
 from dask.graph_manipulation import bind
 
-from ._dask import _roi_from_chunks, unpack_chunks
+from ._dask import _roi_from_chunks, unpack_chunks, randomize
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
@@ -312,7 +312,7 @@ def _da_from_mem(
     darr = da.block(arr.tolist())
 
     # only to retain the node/task name
-    return darr.map_blocks(lambda x: x, name=name)
+    return darr.map_blocks(lambda x: x, name=randomize(name))
 
 
 def da_mem_sink(xx: da.Array, chunks: tuple[int, ...], name="memsink") -> da.Array:


### PR DESCRIPTION
Dask has updated `map_blocks` to align the `name` and `token` args with other funcs, and `name` is now required to be unique.