### PR TITLE
Keep dataset project coords

### DIFF
--- a/odc/algo/_geomedian.py
+++ b/odc/algo/_geomedian.py
@@ -119,7 +119,11 @@ def xr_geomedian(ds, axis="time", where=None, **kw):
         return data
 
     dims = [dim for dim in xx.dims if dim is not axis]  # Drop `time`
-    cc = {coord_name: coord for (coord_name, coord) in xx.coords.items() if axis not in coord.dims}
+    cc = {
+        coord_name: coord
+        for (coord_name, coord) in xx.coords.items()
+        if axis not in coord.dims
+    }
     xx_out = xr.DataArray(data, dims=dims, coords=cc)
 
     if ds is None:
@@ -440,7 +444,11 @@ def geomedian_with_mads(
 
     drop_dim = yxbt.dims[3]
     dims = yxbt.dims[:3]
-    coords = {coord_name: coord for (coord_name, coord) in yxbt.coords.items() if drop_dim not in coord.dims}
+    coords = {
+        coord_name: coord
+        for (coord_name, coord) in yxbt.coords.items()
+        if drop_dim not in coord.dims
+    }
 
     result = xr.DataArray(
         data=_gm[:, :, :nb].astype(yxbt.dtype),

--- a/odc/algo/_geomedian.py
+++ b/odc/algo/_geomedian.py
@@ -118,8 +118,8 @@ def xr_geomedian(ds, axis="time", where=None, **kw):
     if xx is None:
         return data
 
-    dims = xx.dims[:-1]
-    cc = {k: xx.coords[k] for k in dims}
+    dims = [dim for dim in xx.dims if dim is not axis]  # Drop `time`
+    cc = {coord_name: coord for (coord_name, coord) in xx.coords.items() if axis not in coord.dims}
     xx_out = xr.DataArray(data, dims=dims, coords=cc)
 
     if ds is None:
@@ -438,8 +438,10 @@ def geomedian_with_mads(
     if out_chunks is not None:
         _gm = _gm.rechunk(out_chunks)
 
+    drop_dim = yxbt.dims[3]
     dims = yxbt.dims[:3]
-    coords = {k: yxbt.coords[k] for k in dims}
+    coords = {coord_name: coord for (coord_name, coord) in yxbt.coords.items() if drop_dim not in coord.dims}
+
     result = xr.DataArray(
         data=_gm[:, :, :nb].astype(yxbt.dtype),
         dims=dims,

--- a/tests/test_geomedian.py
+++ b/tests/test_geomedian.py
@@ -7,7 +7,7 @@ import dask.array as da
 import numpy as np
 from xarray import DataArray, Dataset
 
-from odc.algo import geomedian_with_mads, wait_for_future
+from odc.algo import geomedian_with_mads, wait_for_future, xr_geomedian
 
 
 def test_geomedian_yxbt():
@@ -25,9 +25,10 @@ def test_geomedian_yxbt():
         np.datetime64("2023-04-09"),
     ]
     bcoords = ["b1", "b2", "b3", "b4", "b5"]
+    srcoords = "epsg:1234"
     src = DataArray(
         yxbt,
-        coords={"x": xcoords, "y": ycoords, "time": tcoords, "band": bcoords},
+        coords={"x": xcoords, "y": ycoords, "time": tcoords, "band": bcoords, "spatial_ref": srcoords},
         dims=["y", "x", "band", "time"],
     )
     result = geomedian_with_mads(src)
@@ -39,6 +40,7 @@ def test_geomedian_yxbt():
     assert "bcmad" in computed_result.data_vars
     assert "band" not in computed_result.dims
     assert "x" in computed_result.dims
+    assert "spatial_ref" in computed_result.coords
 
 
 def test_geomedian_dataset():
@@ -89,6 +91,7 @@ def test_geomedian_dataset():
         coords={"x": xcoords, "y": ycoords, "time": tcoords},
         dims=["time", "y", "x"],
     )
+    srcoords = "epsg:1234"
 
     src = Dataset(
         data_vars={
@@ -98,7 +101,7 @@ def test_geomedian_dataset():
             "b4": b4,
             "b5": b5,
         },
-        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        coords={"x": xcoords, "y": ycoords, "time": tcoords, "spatial_ref": srcoords},
     )
     result = geomedian_with_mads(src)
     assert dask.is_dask_collection(result)
@@ -109,6 +112,7 @@ def test_geomedian_dataset():
     assert "bcmad" in computed_result.data_vars
     assert "band" not in computed_result.dims
     assert "x" in computed_result.dims
+    assert "spatial_ref" in computed_result.coords
 
 
 # @pytest.mark.skip
@@ -213,5 +217,110 @@ def test_geomedian_mem():
     assert "band" not in complete_result.data_vars
     assert "b1" in complete_result.data_vars
     assert "bcmad" in complete_result.data_vars
+    assert "band" not in complete_result.dims
+    assert "x" in complete_result.dims
+
+# @pytest.mark.skip
+def test_geomedian_nomads():
+    client = dask.distributed.Client(
+        n_workers=1, threads_per_worker=1, memory_limit=9663676416, processes=False
+    )
+    # Sleep long enough to start dask console
+    # time.sleep(8)
+    # NT, NY, NX = 7, 3200, 3200
+    # work_chunks = (400, 400)
+    NT, NY, NX = 4, 1200, 1200
+    work_chunks = (400, 400)
+
+    xcoords = list(range(0, NX * 5, 5))
+    ycoords = list(range(0, NY * 5, 5))
+    tcoords = [
+        np.datetime64("2023-04-07"),
+        np.datetime64("2023-04-08"),
+        np.datetime64("2023-04-09"),
+        np.datetime64("2023-04-10"),
+        np.datetime64("2023-04-11"),
+        np.datetime64("2023-04-12"),
+        np.datetime64("2023-04-13"),
+        np.datetime64("2023-04-14"),
+        np.datetime64("2023-04-15"),
+        np.datetime64("2023-04-16"),
+        np.datetime64("2023-04-17"),
+        np.datetime64("2023-04-18"),
+        np.datetime64("2023-04-19"),
+        np.datetime64("2023-04-20"),
+    ][:NT]
+
+    rng = np.random.default_rng()
+    b1 = DataArray(
+        da.from_array(
+            rng.random(dtype=da.float32, size=(NT, NY, NX)), chunks=(1, 800, 800)
+        ),
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        dims=["time", "y", "x"],
+    )
+    b2 = DataArray(
+        da.from_array(
+            rng.random(dtype=da.float32, size=(NT, NY, NX)), chunks=(1, 800, 800)
+        ),
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        dims=["time", "y", "x"],
+    )
+    b3 = DataArray(
+        da.from_array(
+            rng.random(dtype=da.float32, size=(NT, NY, NX)), chunks=(1, 800, 800)
+        ),
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        dims=["time", "y", "x"],
+    )
+    b4 = DataArray(
+        da.from_array(
+            rng.random(dtype=da.float32, size=(NT, NY, NX)), chunks=(1, 800, 800)
+        ),
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        dims=["time", "y", "x"],
+    )
+    b5 = DataArray(
+        da.from_array(
+            rng.random(dtype=da.float32, size=(NT, NY, NX)), chunks=(1, 800, 800)
+        ),
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        dims=["time", "y", "x"],
+    )
+    b6 = DataArray(
+        da.from_array(
+            rng.random(dtype=da.float32, size=(NT, NY, NX)), chunks=(1, 800, 800)
+        ),
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+        dims=["time", "y", "x"],
+    )
+
+    src = Dataset(
+        data_vars={
+            "b1": b1,
+            "b2": b2,
+            "b3": b3,
+            "b4": b4,
+            "b5": b5,
+            "b6": b6,
+        },
+        coords={"x": xcoords, "y": ycoords, "time": tcoords},
+    )
+    result = xr_geomedian(
+        src,
+        max_iters=1000,
+        num_threads=1,
+        out_chunks=(-1, -1, -1),
+        work_chunks=work_chunks,
+    )
+    assert dask.is_dask_collection(result)
+    running_result = client.compute(result)
+    for _ in wait_for_future(running_result, 100):
+        pass
+    complete_result = running_result.result()
+    assert not dask.is_dask_collection(complete_result)
+    assert "band" not in complete_result.data_vars
+    assert "b1" in complete_result.data_vars
+    assert "bcmad" not in complete_result.data_vars
     assert "band" not in complete_result.dims
     assert "x" in complete_result.dims

--- a/tests/test_geomedian.py
+++ b/tests/test_geomedian.py
@@ -28,7 +28,13 @@ def test_geomedian_yxbt():
     srcoords = "epsg:1234"
     src = DataArray(
         yxbt,
-        coords={"x": xcoords, "y": ycoords, "time": tcoords, "band": bcoords, "spatial_ref": srcoords},
+        coords={
+            "x": xcoords,
+            "y": ycoords,
+            "time": tcoords,
+            "band": bcoords,
+            "spatial_ref": srcoords,
+        },
         dims=["y", "x", "band", "time"],
     )
     result = geomedian_with_mads(src)
@@ -219,6 +225,7 @@ def test_geomedian_mem():
     assert "bcmad" in complete_result.data_vars
     assert "band" not in complete_result.dims
     assert "x" in complete_result.dims
+
 
 # @pytest.mark.skip
 def test_geomedian_nomads():


### PR DESCRIPTION
Geomedian produced a `xarray.Dataset` without the non-dim named coords, including `spatial_ref`, which lost the projection information. Now we only drop the coords that have the target dimension (eg `time`).

Closes #63